### PR TITLE
Fix: Hide scroll to top button when already on top

### DIFF
--- a/index.html
+++ b/index.html
@@ -978,7 +978,7 @@
     <!--For Top Scroll Button -->
     <a href="#" id="toTopBtn" class="cd-top text-replace js-cd-top cd-top--is-visible cd-top--fade-out"
         data-abc="true"></a>
-    
+    <script src="https://code.jquery.com/jquery-3.6.1.min.js" integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ=" crossorigin="anonymous"></script>
     <script src="index.js"></script>
 
 </body>

--- a/style.css
+++ b/style.css
@@ -213,6 +213,7 @@ button:hover {
  padding: 21px;
  background-color: #2666cf;
  border-radius: 25%;
+ display: none;
 }
 
 .js .cd-top--fade-out {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
Before this PR, there were two bugs:
1. The jQuery plugin was missing, due to which animation wasn't working when the scroll to top button was clicked.
2. The `display: none` CSS property was missing in the scroll to top button, due to which it was being displayed when already on the top of the page.

After this PR:
1. Added the jQuery plugin, so animations are working perfectly.
2. The scroll to top button isn't displayed at the top of the page.

Refer to the attached video.

https://user-images.githubusercontent.com/47353498/194992467-34c7f048-fe58-45a7-8295-3fcddd29941d.mp4

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fixes: #97 
